### PR TITLE
Provides another middleware to track only messages consumed by a worker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "Tideways\\SymfonyMessenger\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tideways\\Tests\\SymfonyMessenger\\": "tests/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "^10.1"
     }

--- a/src/TidewaysOnlyConsumedByWorkerMiddleware.php
+++ b/src/TidewaysOnlyConsumedByWorkerMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tideways\SymfonyMessenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+
+class TidewaysOnlyConsumedByWorkerMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (!class_exists('Tideways\Profiler') || $envelope->last(ConsumedByWorkerStamp::class) === null) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        \Tideways\Profiler::start();
+        \Tideways\Profiler::setTransactionName(get_class($envelope->getMessage()));
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } catch (HandlerFailedException $e) {
+            \Tideways\Profiler::logException($e);
+
+            throw $e;
+        } finally {
+            \Tideways\Profiler::stop();
+        }
+    }
+}

--- a/tests/TidewaysMiddlewareTest.php
+++ b/tests/TidewaysMiddlewareTest.php
@@ -1,16 +1,21 @@
 <?php
 
-namespace Tideways\SymfonyMessenger;
+namespace Tideways\Tests\SymfonyMessenger;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Tideways\SymfonyMessenger\TidewaysMiddleware;
 
+#[CoversClass(TidewaysMiddleware::class)]
 class TidewaysMiddlewareTest extends TestCase
 {
     public function testHandle(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $next = $this->createStub(MiddlewareInterface::class);
         $next->method('handle')->willReturn(new Envelope(new \stdClass));
         $stack = $this->createStub(StackInterface::class);

--- a/tests/TidewaysOnlyConsumedByWorkerMiddlewareTest.php
+++ b/tests/TidewaysOnlyConsumedByWorkerMiddlewareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tideways\Tests\SymfonyMessenger;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Tideways\SymfonyMessenger\TidewaysOnlyConsumedByWorkerMiddleware;
+
+#[CoversClass(TidewaysOnlyConsumedByWorkerMiddleware::class)]
+class TidewaysOnlyConsumedByWorkerMiddlewareTest extends TestCase
+{
+    public function testHandleWithOutConsumedByWorkerStamp(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $envelope = new Envelope(new \stdClass);
+
+        $next = $this->createStub(MiddlewareInterface::class);
+        $next->method('handle')->willReturn($envelope);
+        $stack = $this->createStub(StackInterface::class);
+        $stack->method('next')->willReturn($next);
+
+        $middleware = new TidewaysOnlyConsumedByWorkerMiddleware();
+        $middleware->handle($envelope, $stack);
+    }
+
+    public function testHandleWithConsumedByWorkerStamp(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $envelope = new Envelope(new \stdClass, [new ConsumedByWorkerStamp()]);
+
+        $next = $this->createStub(MiddlewareInterface::class);
+        $next->method('handle')->willReturn($envelope);
+        $stack = $this->createStub(StackInterface::class);
+        $stack->method('next')->willReturn($next);
+
+        $middleware = new TidewaysOnlyConsumedByWorkerMiddleware();
+        $middleware->handle($envelope, $stack);
+    }
+}


### PR DESCRIPTION
Hey :wave:,

in case the transport for a message has been configured async, we would get with the current middleware the sending and the consumed part as a trace.

E.g.
![image](https://user-images.githubusercontent.com/183530/234870555-d1e256c5-8bc2-4267-8465-81ba916ae339.png)

I think the sending trace is not very interesting and can stay within the actual (main) request. The most interesting part is when the message gets consumed and handled. Symfony provides a stamp which gets added to the envelop when the message got consumed by a worker.
